### PR TITLE
cancel orders and reverse inventory updates

### DIFF
--- a/app/lib/qbo.rb
+++ b/app/lib/qbo.rb
@@ -99,6 +99,12 @@ module Qbo
     service.create(journal_entry)
   end
 
+  def self.delete_journal_entry(journal_entry_id)
+    service = Quickbooks::Service::JournalEntry.new(service_params)
+    journal_entry = service.fetch_by_id(journal_entry_id)
+    service.delete(journal_entry)
+  end
+
   def self.journal_entry_line_item(params, entry_details)
     line = Quickbooks::Model::Line.new(params)
 

--- a/app/lib/vend_client.rb
+++ b/app/lib/vend_client.rb
@@ -186,8 +186,8 @@ class VendClient
     response.body['data']
   end
 
-  def self.send_consignment(consignment_id)
-    body = { status: 'SENT' }
+  def self.update_consignment_status(consignment_id, status)
+    body = { status: status }
 
     response = connection.put do |req|
       req.url "consignments/#{consignment_id}"

--- a/app/models/daily_inventory_transfer.rb
+++ b/app/models/daily_inventory_transfer.rb
@@ -99,6 +99,7 @@ class DailyInventoryTransfer < ApplicationRecord
   end
 
   def cancel
+    return if cancelled?
     daily_orders.not_cancelled.each do |daily_order|
       daily_order.cancel
     end
@@ -111,6 +112,7 @@ end
 # Table name: daily_inventory_transfers
 #
 #  id         :bigint(8)        not null, primary key
+#  cancelled  :boolean          default(FALSE)
 #  date       :datetime
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/models/daily_inventory_transfer.rb
+++ b/app/models/daily_inventory_transfer.rb
@@ -3,6 +3,14 @@
 class DailyInventoryTransfer < ApplicationRecord
   has_many :daily_orders, dependent: :destroy
 
+  scope :cancelled, lambda {
+    where(cancelled: true)
+  }
+
+  scope :not_cancelled, lambda {
+    where(cancelled: false)
+  }
+
   def self.last_po
     maximum(:po_id).to_i
   end
@@ -88,6 +96,13 @@ class DailyInventoryTransfer < ApplicationRecord
     end
 
     journal_entry
+  end
+
+  def cancel
+    daily_orders.not_cancelled.each do |daily_order|
+      daily_order.cancel
+    end
+    update_attribute(:cancelled, true) if daily_orders.not_cancelled.count.zero?
   end
 end
 

--- a/app/models/daily_inventory_transfer.rb
+++ b/app/models/daily_inventory_transfer.rb
@@ -111,7 +111,7 @@ class DailyInventoryTransfer < ApplicationRecord
   end
 
   def delete_qbo_journal_entry
-    QBO.delete_journal_entry(qbo_id)
+    Qbo.delete_journal_entry(qbo_id)
     update_attribute(:qbo_id, nil)
   end
 end

--- a/app/models/daily_inventory_transfer.rb
+++ b/app/models/daily_inventory_transfer.rb
@@ -103,7 +103,16 @@ class DailyInventoryTransfer < ApplicationRecord
     daily_orders.not_cancelled.each do |daily_order|
       daily_order.cancel
     end
-    update_attribute(:cancelled, true) if daily_orders.not_cancelled.count.zero?
+
+    if daily_orders.not_cancelled.count.zero?
+      delete_qbo_journal_entry
+      update_attribute(:cancelled, true)
+    end
+  end
+
+  def delete_qbo_journal_entry
+    QBO.delete_journal_entry(qbo_id)
+    update_attribute(:qbo_id, nil)
   end
 end
 

--- a/app/models/daily_inventory_transfer.rb
+++ b/app/models/daily_inventory_transfer.rb
@@ -37,7 +37,7 @@ class DailyInventoryTransfer < ApplicationRecord
     pos = []
     total_cost = 0
 
-    daily_orders.each do |daily_order|
+    daily_orders.not_cancelled.each do |daily_order|
       next unless daily_order.orders.count.positive?
 
       details << {

--- a/app/models/daily_order.rb
+++ b/app/models/daily_order.rb
@@ -188,6 +188,7 @@ class DailyOrder < ApplicationRecord
     orders.not_cancelled.each do |order|
       order.cancel
     end
+
     if orders.not_cancelled.count.zero?
       cancel_consignment
       update_attribute(:cancelled, true)

--- a/app/models/daily_order.rb
+++ b/app/models/daily_order.rb
@@ -178,6 +178,7 @@ class DailyOrder < ApplicationRecord
   end
 
   def cancel
+    return if cancelled?
     orders.not_cancelled.each do |order|
       order.cancel
     end
@@ -190,6 +191,7 @@ end
 # Table name: daily_orders
 #
 #  id                          :bigint(8)        not null, primary key
+#  cancelled                   :boolean          default(FALSE)
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  daily_inventory_transfer_id :integer

--- a/app/models/daily_order.rb
+++ b/app/models/daily_order.rb
@@ -5,6 +5,14 @@ class DailyOrder < ApplicationRecord
   has_many :orders, dependent: :destroy
   delegate :po_id, to: :daily_inventory_transfer
 
+  scope :cancelled, lambda {
+    where(cancelled: true)
+  }
+
+  scope :not_cancelled, lambda {
+    where(cancelled: false)
+  }
+
   PO_ADDRESSES = {
     'San Francisco' => 'Mollusk Surf Shop (San Francisco)<br />4500 Irving Street<br />San Francisco, CA 94122-1132',
     'Venice Beach' => 'Mollusk Surf Shop (Venice Beach)<br />1600 Pacific Avenue<br />Venice Beach, CA 90291-9998',
@@ -167,6 +175,13 @@ class DailyOrder < ApplicationRecord
 
   def vend_consignment_url
     "https://mollusksurf.vendhq.com/consignment/#{vend_consignment_id}" if vend_consignment_id.present?
+  end
+
+  def cancel
+    orders.not_cancelled.each do |order|
+      order.cancel
+    end
+    update_attribute(:cancelled, true) if orders.not_cancelled.count.zero?
   end
 end
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -7,8 +7,21 @@ class Order < ApplicationRecord
 
   after_create :reduce_warehouse_inventory
 
+  scope :cancelled, lambda {
+    where(cancelled: true)
+  }
+
+  scope :not_cancelled, lambda {
+    where(cancelled: false)
+  }
+
   def reduce_warehouse_inventory
     product.adjust_order_inventory(self)
+  end
+
+  def cancel
+    product.undo_adjust_order_inventory(self)
+    update_attribute(:cancelled, true) if order_inventory_update.undone?
   end
 
   def total_cost

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -20,6 +20,7 @@ class Order < ApplicationRecord
   end
 
   def cancel
+    return if cancelled?
     product.undo_adjust_order_inventory(self)
     update_attribute(:cancelled, true) if order_inventory_update.undone?
   end
@@ -34,6 +35,7 @@ end
 # Table name: orders
 #
 #  id             :bigint(8)        not null, primary key
+#  cancelled      :boolean          default(FALSE)
 #  cost           :float
 #  quantity       :integer
 #  sent_orders    :integer          default(0)

--- a/app/models/order_inventory_update.rb
+++ b/app/models/order_inventory_update.rb
@@ -10,9 +10,6 @@ class OrderInventoryUpdate < ApplicationRecord
   def undo
     update_attribute(:undone, true)
   end
-
-  # need to add an undo method here
-  def undo; end
 end
 
 # == Schema Information
@@ -22,6 +19,7 @@ end
 #  id            :bigint(8)        not null, primary key
 #  new_jam_qty   :integer
 #  prior_jam_qty :integer
+#  undone        :boolean          default(FALSE)
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  order_id      :integer

--- a/app/models/order_inventory_update.rb
+++ b/app/models/order_inventory_update.rb
@@ -7,6 +7,10 @@ class OrderInventoryUpdate < ApplicationRecord
     new_jam_qty == (prior_jam_qty - order.quantity)
   end
 
+  def undo
+    update_attribute(:undone, true)
+  end
+
   # need to add an undo method here
   def undo; end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -286,12 +286,12 @@ class Product < ApplicationRecord
         shopify_inventory.update_attribute(:inventory, updated_warehouse_inventory)
         order.order_inventory_update.undo
 
-        Airbrake.notify("ORDER INVENTORY UNDO/Cancel: Product #{id} expected warehouse qty #{expected_warehouse_inventory} but got #{updated_warehouse_inventory}") unless expected_warehouse_inventory == updated_warehouse_inventory
+        Airbrake.notify("ORDER (#{order.id}) INVENTORY UNDO/Cancel: Product #{id} expected warehouse qty #{expected_warehouse_inventory} but got #{updated_warehouse_inventory}") unless expected_warehouse_inventory == updated_warehouse_inventory
       else
-        Airbrake.notify("Could not UPDATE warehouse inventory during ORDER UNDO/Cancel for Product: #{id}, Adjustment: #{order.quantity}")
+        Airbrake.notify("Could not UPDATE warehouse inventory during ORDER (#{order.id}) UNDO/Cancel for Product: #{id}, Adjustment: #{order.quantity}")
       end
     rescue
-      Airbrake.notify("There was an error UPDATING warehouse inventory during ORDER UNDO/Cancel of Product: #{id}, Adjustment: #{order.quantity}")
+      Airbrake.notify("There was an error UPDATING warehouse inventory during ORDER (#{order.id}) UNDO/Cancel of Product: #{id}, Adjustment: #{order.quantity}")
     end
   end
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -282,6 +282,7 @@ class Product < ApplicationRecord
         updated_warehouse_inventory = response['inventory_level']['available']
         shopify_inventory = retail_shopify.shopify_inventories.find_by(location: 'Postworks')
         expected_warehouse_inventory = shopify_inventory.inventory + order.quantity
+
         shopify_inventory.update_attribute(:inventory, updated_warehouse_inventory)
         order.order_inventory_update.undo
 

--- a/db/migrate/20200707234845_add_cancelled_to_daily_orders.rb
+++ b/db/migrate/20200707234845_add_cancelled_to_daily_orders.rb
@@ -1,0 +1,5 @@
+class AddCancelledToDailyOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :daily_orders, :cancelled, :boolean, default: false
+  end
+end

--- a/db/migrate/20200707234959_add_cancelled_to_orders.rb
+++ b/db/migrate/20200707234959_add_cancelled_to_orders.rb
@@ -1,0 +1,5 @@
+class AddCancelledToOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :orders, :cancelled, :boolean, default: false
+  end
+end

--- a/db/migrate/20200707235028_add_cancelled_to_daily_inventory_transfers.rb
+++ b/db/migrate/20200707235028_add_cancelled_to_daily_inventory_transfers.rb
@@ -1,0 +1,5 @@
+class AddCancelledToDailyInventoryTransfers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :daily_inventory_transfers, :cancelled, :boolean, default: false
+  end
+end

--- a/db/migrate/20200708002705_add_undone_to_order_inventory_updates.rb
+++ b/db/migrate/20200708002705_add_undone_to_order_inventory_updates.rb
@@ -1,0 +1,5 @@
+class AddUndoneToOrderInventoryUpdates < ActiveRecord::Migration[5.2]
+  def change
+    add_column :order_inventory_updates, :undone, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_18_232243) do
+ActiveRecord::Schema.define(version: 2020_07_08_002705) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 2020_02_18_232243) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "po_id"
+    t.boolean "cancelled", default: false
   end
 
   create_table "daily_orders", force: :cascade do |t|
@@ -36,6 +37,7 @@ ActiveRecord::Schema.define(version: 2020_02_18_232243) do
     t.datetime "updated_at", null: false
     t.string "vend_consignment_id"
     t.integer "daily_inventory_transfer_id"
+    t.boolean "cancelled", default: false
   end
 
   create_table "daily_vend_consignments", force: :cascade do |t|
@@ -87,6 +89,7 @@ ActiveRecord::Schema.define(version: 2020_02_18_232243) do
     t.integer "order_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "undone", default: false
   end
 
   create_table "orders", force: :cascade do |t|
@@ -99,6 +102,7 @@ ActiveRecord::Schema.define(version: 2020_02_18_232243) do
     t.datetime "updated_at", null: false
     t.float "cost"
     t.integer "sent_orders", default: 0
+    t.boolean "cancelled", default: false
   end
 
   create_table "products", force: :cascade do |t|

--- a/test/fixtures/daily_inventory_transfers.yml
+++ b/test/fixtures/daily_inventory_transfers.yml
@@ -13,6 +13,7 @@ two:
 # Table name: daily_inventory_transfers
 #
 #  id         :bigint(8)        not null, primary key
+#  cancelled  :boolean          default(FALSE)
 #  date       :datetime
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/test/fixtures/daily_orders.yml
+++ b/test/fixtures/daily_orders.yml
@@ -11,6 +11,7 @@ two:
 # Table name: daily_orders
 #
 #  id                          :bigint(8)        not null, primary key
+#  cancelled                   :boolean          default(FALSE)
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  daily_inventory_transfer_id :integer

--- a/test/fixtures/order_inventory_updates.yml
+++ b/test/fixtures/order_inventory_updates.yml
@@ -17,6 +17,7 @@ two:
 #  id            :bigint(8)        not null, primary key
 #  new_jam_qty   :integer
 #  prior_jam_qty :integer
+#  undone        :boolean          default(FALSE)
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  order_id      :integer

--- a/test/fixtures/orders.yml
+++ b/test/fixtures/orders.yml
@@ -17,6 +17,7 @@ two:
 # Table name: orders
 #
 #  id             :bigint(8)        not null, primary key
+#  cancelled      :boolean          default(FALSE)
 #  cost           :float
 #  quantity       :integer
 #  sent_orders    :integer          default(0)

--- a/test/models/daily_inventory_transfer_test.rb
+++ b/test/models/daily_inventory_transfer_test.rb
@@ -13,6 +13,7 @@ end
 # Table name: daily_inventory_transfers
 #
 #  id         :bigint(8)        not null, primary key
+#  cancelled  :boolean          default(FALSE)
 #  date       :datetime
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/test/models/daily_order_test.rb
+++ b/test/models/daily_order_test.rb
@@ -13,6 +13,7 @@ end
 # Table name: daily_orders
 #
 #  id                          :bigint(8)        not null, primary key
+#  cancelled                   :boolean          default(FALSE)
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  daily_inventory_transfer_id :integer

--- a/test/models/order_inventory_update_test.rb
+++ b/test/models/order_inventory_update_test.rb
@@ -15,6 +15,7 @@ end
 #  id            :bigint(8)        not null, primary key
 #  new_jam_qty   :integer
 #  prior_jam_qty :integer
+#  undone        :boolean          default(FALSE)
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  order_id      :integer

--- a/test/models/order_test.rb
+++ b/test/models/order_test.rb
@@ -13,6 +13,7 @@ end
 # Table name: orders
 #
 #  id             :bigint(8)        not null, primary key
+#  cancelled      :boolean          default(FALSE)
 #  cost           :float
 #  quantity       :integer
 #  sent_orders    :integer          default(0)


### PR DESCRIPTION
Work in progress.

So far, orders can be cancelled for all stores, one store or just one line item.

When a store's order is cancelled, all of its line items are cancelled

When a line item is cancelled, the shopify warehouse inventory reduction associated with that line-item is undone